### PR TITLE
fixed hashable check in __call__

### DIFF
--- a/memorize/memorize.py
+++ b/memorize/memorize.py
@@ -77,15 +77,16 @@ class Memorize(object):
 
     def __call__(self, *args):
         self.check_cache()
-        if not isinstance(args, collections.Hashable):
+        try:
+            if args in self.cache:
+                return self.cache[args]
+            else:
+                value = self.func(*args)
+                self.cache[args] = value
+                self.save_cache()
+                return value
+        except TypeError: # unhashable arguments
             return self.func(*args)
-        if args in self.cache:
-            return self.cache[args]
-        else:
-            value = self.func(*args)
-            self.cache[args] = value
-            self.save_cache()
-            return value
 
     def get_cache_filename(self):
         """


### PR DESCRIPTION
isinstance(x, hashable) doesn't work when there's a nested unhashable type, for example a list in a tuple.
What does work is a try: hash(x); except TypeError: donthash(x).
A better option would be to add some deepfreeze dependency or even just use str(x) or x.__repr__() or the like instead maybe, assuming the overhead for str() is less than the one for running the function again (which is the main reason to wrap it in a memorize).